### PR TITLE
opt-in download for large media (>100 MB inline preview cutoff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These apps solve different problems; the table is to set expectations, not to pi
 
 - **Room key is the capability.** Anyone with it can join the swarm and decrypt traffic for that room. Treat it like a strong shared secret.
 - **No “real” host** in the network sense: peers are symmetric. “Host” in the UI only marks who created the room on that device.
-- Rate limits, a max **message text** length, and moderation filters cut spam and obvious unsafe content in the feed; file uploads have **no size limit** in the app. The UI escapes text before rendering to limit XSS.
+- Rate limits, a max **message text** length, and moderation filters cut spam and obvious unsafe content in the feed; file uploads have **no size limit** in the app. Inline image/video previews are automatically shown for files up to 100 MB; larger files render as a click-to-load placeholder card. The UI escapes text before rendering to limit XSS.
 - Moderation is local and heuristic, not a trust or safety service. It helps with accidental exposure and noisy peers, but it does not replace trusted room keys, identity verification, or user judgment.
 - **Not** Matrix/Signal-class identity, device verification, or perfect forward secrecy.
 

--- a/app.js
+++ b/app.js
@@ -150,7 +150,30 @@ function formatFileSize(bytes) {
 }
 
 function shouldAutoInline(fileSize) {
-  return fileSize == null || fileSize <= AUTO_INLINE_PREVIEW_MAX_BYTES;
+  return fileSize != null && fileSize <= AUTO_INLINE_PREVIEW_MAX_BYTES;
+}
+
+function expandLargeMedia(wrap) {
+  const url = wrap.getAttribute("data-file-url");
+  if (!url) return;
+  const openZone = wrap.querySelector(".msg-file-attach-open");
+  if (openZone) openZone.innerHTML = '<span class="muted small">Loading…</span>';
+  const mediaType = wrap.getAttribute("data-large-type") || 'image';
+  const isVideo = mediaType === 'video';
+  const el = document.createElement(isVideo ? 'video' : 'img');
+  el.className = 'msg-file-img';
+  if (isVideo) {
+    el.src = url;
+    el.controls = true;
+    el.preload = 'metadata';
+    el.muted = true;
+  } else {
+    el.src = url;
+    el.alt = 'image';
+    el.loading = 'lazy';
+  }
+  wrap.replaceWith(el);
+  el.focus();
 }
 
 function isHyperFileUrl(url) {
@@ -2451,11 +2474,7 @@ document.addEventListener("click", (ev) => {
     const url = wrap?.getAttribute("data-file-url");
     if (!url) return;
     if (wrap?.classList.contains("large-media-placeholder")) {
-      const mediaType = wrap.getAttribute("data-large-type") || 'image';
-      const mediaHtml = mediaType === 'video'
-        ? `<video class="msg-file-img" src="${esc(url)}" controls preload="metadata" muted></video>`
-        : `<img class="msg-file-img" src="${esc(url)}" alt="image" loading="lazy" />`;
-      wrap.outerHTML = mediaHtml;
+      expandLargeMedia(wrap);
     } else {
       window.open(url);
     }
@@ -2519,11 +2538,7 @@ if (msgArea) {
       const url = wrap?.getAttribute("data-file-url");
       if (!url) return;
       if (wrap?.classList.contains("large-media-placeholder")) {
-        const mediaType = wrap.getAttribute("data-large-type") || 'image';
-        const mediaHtml = mediaType === 'video'
-          ? `<video class="msg-file-img" src="${esc(url)}" controls preload="metadata" muted></video>`
-          : `<img class="msg-file-img" src="${esc(url)}" alt="image" loading="lazy" />`;
-        wrap.outerHTML = mediaHtml;
+        expandLargeMedia(wrap);
       } else {
         window.open(url);
       }

--- a/app.js
+++ b/app.js
@@ -221,7 +221,7 @@ function largeMediaHtml(url, fileNameOpt, fileSizeOpt, mediaType) {
   const escU = esc(url);
   const escN = esc(name);
   const iconSvg = './assets/svg/p2p.svg';
-  return `<div class="msg-file-attach large-media-placeholder" data-large-url="${escU}" data-large-type="${mediaType}">
+  return `<div class="msg-file-attach large-media-placeholder" data-file-url="${escU}" data-large-type="${mediaType}">
     <div class="msg-file-attach-open" role="button" tabindex="0" aria-label="Load media">
       <div class="msg-file-attach-icon"><img class="msg-file-attach-icon-img" src="${iconSvg}" alt="" width="36" height="36" /></div>
       <div class="msg-file-attach-info">

--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ const S = {
 };
 
 const REACT_EMOJIS = ["👍", "❤️", "😂", "😮", "😢", "🔥"];
+const AUTO_INLINE_PREVIEW_MAX_BYTES = 100 * 1024 * 1024;
 
 let globalES = null;
 let reconnectTimer = null;
@@ -148,6 +149,10 @@ function formatFileSize(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
 }
 
+function shouldAutoInline(fileSize) {
+  return fileSize == null || fileSize <= AUTO_INLINE_PREVIEW_MAX_BYTES;
+}
+
 function isHyperFileUrl(url) {
   if (!(/^hyper:\/\//i.test(url))) return false;
   if (isImageFile(url) || isVideoFile(url)) return false;
@@ -199,6 +204,26 @@ function fileAttachHtml(url, fileNameOpt, fileSizeOpt) {
   return `<div class="msg-file-attach" data-file-url="${escU}">
     <div class="msg-file-attach-open" role="link" tabindex="0" aria-label="Open file in new tab">
       <div class="msg-file-attach-icon"><img class="msg-file-attach-icon-img" src="./assets/svg/p2p.svg" alt="" width="36" height="36" /></div>
+      <div class="msg-file-attach-info">
+        <span class="msg-file-attach-name">${escN}</span>
+        ${sizeLbl ? `<span class="msg-file-attach-size">${esc(sizeLbl)}</span>` : ""}
+      </div>
+    </div>
+    <button type="button" class="msg-file-attach-dl-btn" aria-label="Download file" data-file-url="${escU}" data-file-name="${escN}">
+      <img class="msg-file-attach-dl-icon" src="./assets/svg/download.svg" alt="" width="20" height="20" />
+    </button>
+  </div>`;
+}
+
+function largeMediaHtml(url, fileNameOpt, fileSizeOpt, mediaType) {
+  const name = fileNameOpt || displayNameFromHyperPath(url);
+  const sizeLbl = formatFileSize(fileSizeOpt);
+  const escU = esc(url);
+  const escN = esc(name);
+  const iconSvg = './assets/svg/p2p.svg';
+  return `<div class="msg-file-attach large-media-placeholder" data-large-url="${escU}" data-large-type="${mediaType}">
+    <div class="msg-file-attach-open" role="button" tabindex="0" aria-label="Load media">
+      <div class="msg-file-attach-icon"><img class="msg-file-attach-icon-img" src="${iconSvg}" alt="" width="36" height="36" /></div>
       <div class="msg-file-attach-info">
         <span class="msg-file-attach-name">${escN}</span>
         ${sizeLbl ? `<span class="msg-file-attach-size">${esc(sizeLbl)}</span>` : ""}
@@ -405,9 +430,17 @@ function linkify(text, msg) {
     if (url.includes('@') && !url.includes('://')) {
       parts.push(`<a href="mailto:${esc(url)}" target="_blank" rel="noopener noreferrer">${esc(url)}</a>`);
     } else if (isImageFile(url)) {
-      parts.push(`<img class="msg-file-img" src="${esc(url)}" alt="image" loading="lazy" />`);
+      if (shouldAutoInline(msg?.fileSize)) {
+        parts.push(`<img class="msg-file-img" src="${esc(url)}" alt="image" loading="lazy" />`);
+      } else {
+        parts.push(largeMediaHtml(url, msg?.fileName, msg?.fileSize, 'image'));
+      }
     } else if (isVideoFile(url)) {
-      parts.push(`<video class="msg-file-img" src="${esc(url)}" controls preload="metadata" muted></video>`);
+      if (shouldAutoInline(msg?.fileSize)) {
+        parts.push(`<video class="msg-file-img" src="${esc(url)}" controls preload="metadata" muted></video>`);
+      } else {
+        parts.push(largeMediaHtml(url, msg?.fileName, msg?.fileSize, 'video'));
+      }
     } else if (isHyperFileUrl(url)) {
       parts.push(fileAttachHtml(url, null, null));
     } else {
@@ -1233,7 +1266,7 @@ function makeMsgEl(msg) {
   el.appendChild(time);
 
   el.addEventListener("dblclick", (e) => {
-    if (e.target.closest("a, .msg-file-attach-open, .msg-file-attach-dl-btn, .msg-reply-quote, img, video, button, .msg-react-trigger, .reaction-bubble")) return;
+    if (e.target.closest("a, .msg-file-attach-open, .msg-file-attach-dl-btn, .msg-reply-quote, img, video, button, .msg-react-trigger, .reaction-bubble, .large-media-placeholder")) return;
     setReply(msg);
   });
 
@@ -2416,7 +2449,16 @@ document.addEventListener("click", (ev) => {
     ev.stopPropagation();
     const wrap = openZone.closest(".msg-file-attach");
     const url = wrap?.getAttribute("data-file-url");
-    if (url) window.open(url);
+    if (!url) return;
+    if (wrap?.classList.contains("large-media-placeholder")) {
+      const mediaType = wrap.getAttribute("data-large-type") || 'image';
+      const mediaHtml = mediaType === 'video'
+        ? `<video class="msg-file-img" src="${esc(url)}" controls preload="metadata" muted></video>`
+        : `<img class="msg-file-img" src="${esc(url)}" alt="image" loading="lazy" />`;
+      wrap.outerHTML = mediaHtml;
+    } else {
+      window.open(url);
+    }
     return;
   }
   const a = ev.target.closest("a[href]");
@@ -2473,8 +2515,18 @@ if (msgArea) {
     const openZone = e.target.closest(".msg-file-attach-open");
     if (openZone && (e.key === "Enter" || e.key === " ")) {
       e.preventDefault();
-      const url = openZone.closest(".msg-file-attach")?.getAttribute("data-file-url");
-      if (url) window.open(url);
+      const wrap = openZone.closest(".msg-file-attach");
+      const url = wrap?.getAttribute("data-file-url");
+      if (!url) return;
+      if (wrap?.classList.contains("large-media-placeholder")) {
+        const mediaType = wrap.getAttribute("data-large-type") || 'image';
+        const mediaHtml = mediaType === 'video'
+          ? `<video class="msg-file-img" src="${esc(url)}" controls preload="metadata" muted></video>`
+          : `<img class="msg-file-img" src="${esc(url)}" alt="image" loading="lazy" />`;
+        wrap.outerHTML = mediaHtml;
+      } else {
+        window.open(url);
+      }
     }
   });
   msgArea.addEventListener("dragover", (e) => { e.preventDefault(); $("dropzone").style.display = "flex"; });


### PR DESCRIPTION
Images and videos >100 MB are now rendered as a `.msg-file-attach` placeholder card with a download button instead of auto-inlining. Clicking the card body lazy-loads the actual `<img>`/`<video>` inline.

- Added `AUTO_INLINE_PREVIEW_MAX_BYTES = 100 * 1024 * 1024`
- Added `shouldAutoInline()` helper (null fileSize → true for legacy messages)
- Added `largeMediaHtml()` to render the placeholder card
- Gated `linkify()` image/video branches with the size check
- Documented in README under PeerChat specifics

closes #11 